### PR TITLE
Implement dry-run functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,11 @@ You can call `./install --except [list of directives]`, such as `./install
 --except shell`, and Dotbot will run all the sections of the config file except
 the ones listed.
 
+### `--dry-run`
+
+You can call `./install --dry-run` to see what actions would be taken without
+making any changes.
+
 ## Wiki
 
 Check out the [Dotbot wiki][wiki] for more information, tips and tricks,

--- a/src/dotbot/cli.py
+++ b/src/dotbot/cli.py
@@ -51,6 +51,13 @@ def add_options(parser: ArgumentParser) -> None:
     parser.add_argument("--no-color", dest="no_color", action="store_true", help="disable color output")
     parser.add_argument("--version", action="store_true", help="show program's version number and exit")
     parser.add_argument(
+        "-n",
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        help="show what actions would be taken without performing them",
+    )
+    parser.add_argument(
         "-x",
         "--exit-on-failure",
         dest="exit_on_failure",

--- a/src/dotbot/dispatcher.py
+++ b/src/dotbot/dispatcher.py
@@ -64,6 +64,12 @@ class Dispatcher:
                     # keep going, let other plugins handle this if they want
                 for plugin in self._plugins:
                     if plugin.can_handle(action):
+                        if self._context.options().dry_run and not plugin.SUPPORTS_DRY_RUN:
+                            self._log.info(
+                                f"Skipping action {action} for plugin {plugin.__class__.__name__} in dry-run mode"
+                            )
+                            handled = True
+                            continue
                         try:
                             local_success = plugin.handle(action, task[action])
                             if not local_success and self._exit:

--- a/src/dotbot/plugin.py
+++ b/src/dotbot/plugin.py
@@ -5,6 +5,7 @@ from dotbot.messenger import Messenger
 
 
 class Plugin:
+    SUPPORTS_DRY_RUN = False
     """
     Abstract base class for commands that process directives.
     """
@@ -12,6 +13,10 @@ class Plugin:
     def __init__(self, context: Context):
         self._context = context
         self._log = Messenger()
+        self._dry_run = getattr(context.options(), "dry_run", False)
+
+    def dry_run(self) -> bool:
+        return self._dry_run
 
     def can_handle(self, directive: str) -> bool:
         """

--- a/src/dotbot/plugins/clean.py
+++ b/src/dotbot/plugins/clean.py
@@ -11,6 +11,7 @@ class Clean(Plugin):
     """
 
     _directive = "clean"
+    SUPPORTS_DRY_RUN = True
 
     def can_handle(self, directive: str) -> bool:
         return directive == self._directive
@@ -58,7 +59,8 @@ class Clean(Plugin):
                     points_at = points_at[4:]
                 if self._in_directory(path, self._context.base_directory()) or force:
                     self._log.lowinfo(f"Removing invalid link {path} -> {points_at}")
-                    os.remove(path)
+                    if not self.dry_run():
+                        os.remove(path)
                 else:
                     self._log.lowinfo(f"Link {path} -> {points_at} not removed.")
         return True

--- a/src/dotbot/plugins/create.py
+++ b/src/dotbot/plugins/create.py
@@ -10,6 +10,7 @@ class Create(Plugin):
     """
 
     _directive = "create"
+    SUPPORTS_DRY_RUN = True
 
     def can_handle(self, directive: str) -> bool:
         return directive == self._directive
@@ -48,15 +49,18 @@ class Create(Plugin):
         success = True
         if not self._exists(path):
             self._log.debug(f"Trying to create path {path} with mode {mode}")
-            try:
-                self._log.lowinfo(f"Creating path {path}")
-                os.makedirs(path, mode)
-                # On Windows, the *mode* argument to `os.makedirs()` is ignored.
-                # The mode must be set explicitly in a follow-up call.
-                os.chmod(path, mode)
-            except OSError:
-                self._log.warning(f"Failed to create path {path}")
-                success = False
+            if self.dry_run():
+                self._log.lowinfo(f"Would create path {path}")
+            else:
+                try:
+                    self._log.lowinfo(f"Creating path {path}")
+                    os.makedirs(path, mode)
+                    # On Windows, the *mode* argument to `os.makedirs()` is ignored.
+                    # The mode must be set explicitly in a follow-up call.
+                    os.chmod(path, mode)
+                except OSError:
+                    self._log.warning(f"Failed to create path {path}")
+                    success = False
         else:
             self._log.lowinfo(f"Path exists {path}")
         return success

--- a/src/dotbot/plugins/shell.py
+++ b/src/dotbot/plugins/shell.py
@@ -10,6 +10,7 @@ class Shell(Plugin):
     """
 
     _directive = "shell"
+    SUPPORTS_DRY_RUN = True
     _has_shown_override_message = False
 
     def can_handle(self, directive: str) -> bool:
@@ -52,13 +53,17 @@ class Shell(Plugin):
                 self._log.lowinfo(f"{msg} [{cmd}]")
             stdout = options.get("stdout", stdout)
             stderr = options.get("stderr", stderr)
-            ret = shell_command(
-                cmd,
-                cwd=self._context.base_directory(),
-                enable_stdin=stdin,
-                enable_stdout=stdout,
-                enable_stderr=stderr,
-            )
+            if self.dry_run():
+                self._log.lowinfo(f"Would run: {cmd}")
+                ret = 0
+            else:
+                ret = shell_command(
+                    cmd,
+                    cwd=self._context.base_directory(),
+                    enable_stdin=stdin,
+                    enable_stdout=stdout,
+                    enable_stderr=stderr,
+                )
             if ret != 0:
                 success = False
                 self._log.warning(f"Command [{cmd}] failed")

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,26 @@
+import os
+import shutil
+from typing import Callable
+
+from tests.conftest import Dotfiles
+
+
+def test_dry_run_create(home: str, dotfiles: Dotfiles, run_dotbot: Callable[..., None]) -> None:
+    dotfiles.write_config([{"create": ["~/a"]}])
+    run_dotbot("--dry-run")
+    assert not os.path.isdir(os.path.join(home, "a"))
+
+
+def test_dry_run_shell(home: str, dotfiles: Dotfiles, run_dotbot: Callable[..., None]) -> None:
+    dotfiles.write_config([{"shell": ["touch ~/flag"]}])
+    run_dotbot("--dry-run")
+    assert not os.path.exists(os.path.join(home, "flag"))
+
+
+def test_dry_run_third_party_plugin(home: str, dotfiles: Dotfiles, run_dotbot: Callable[..., None]) -> None:
+    plugin_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "dotbot_plugin_file.py")
+    shutil.copy(plugin_file, os.path.join(dotfiles.directory, "file.py"))
+    dotfiles.write_config([{"plugin_file": "~"}])
+    run_dotbot("--dry-run", "--plugin", os.path.join(dotfiles.directory, "file.py"))
+    assert not os.path.exists(os.path.join(home, "flag"))
+


### PR DESCRIPTION
## Summary
- add `--dry-run` CLI option
- allow plugins to advertise dry‑run support
- skip plugins that do not support dry-run
- implement dry-run behavior for built-in plugins
- document new option and add tests

## Testing
- `pip install -q pyyaml`
- `pip install -q -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463ab18290832e80160fd9a372acc8